### PR TITLE
Add _MSHookMemory to symbols list

### DIFF
--- a/CydiaSubstrate.framework/CydiaSubstrate.tbd
+++ b/CydiaSubstrate.framework/CydiaSubstrate.tbd
@@ -8,5 +8,5 @@ exports:
   - archs:            [ armv7, armv7s, arm64, arm64e, i386, x86_64 ]
     symbols:          [ _MSDebug,
                         _MSFindSymbol, _MSGetImageByName,
-                        _MSHookFunction, _MSHookMessageEx ]
+                        _MSHookFunction, _MSHookMessageEx, _MSHookMemory ]
 ...


### PR DESCRIPTION
When I build an app that uses the `MSHookMemory()` and new `substrate.h` (http://apt.saurik.com/beta/substrate11/) with theos,  I get the following error.
```txt
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

To solve it, `_MSHookMemory` is added to symbols list.