### PR TITLE
Add libhooker + libblackjack

### DIFF
--- a/libblackjack.tbd
+++ b/libblackjack.tbd
@@ -1,0 +1,10 @@
+---
+archs:           [ arm64, arm64e, arm64_32 ]
+platform:        ios
+install-name:    '@rpath/libblackjack.dylib'
+current-version: 0.0.0
+compatibility-version: 0.0.0
+exports:
+  - archs:            [ arm64, arm64e, arm64_32 ]
+    symbols:          [ _LBHookMessage ]
+...

--- a/libhooker.tbd
+++ b/libhooker.tbd
@@ -1,0 +1,11 @@
+---
+archs:           [ arm64, arm64e, arm64_32 ]
+platform:        ios
+install-name:    '@rpath/libhooker.dylib'
+current-version: 0.0.0
+compatibility-version: 0.0.0
+exports:
+  - archs:            [ arm64, arm64e, arm64_32 ]
+    symbols:          [ _LHStrError, _LHOpenImage, _LHCloseImage, _LHFindSymbols,
+                        _LHExecMemory, _LHPatchMemory, _LHHookFunctions ]
+...


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Add tbd's for libhooker and libblackjack (requires rpaths to be set for use, though these tbd's will work across both rootfs libhooker [iOS 12 - 14] and rootless libhooker [iOS 15])

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
Used for https://twitter.com/CStar_OW/status/1552136082954760194/photo/1

Any other comments?
-------------------
Verified dylib is linked correctly using otool and that dylib loads with rootless build of libhooker on iOS 15

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iOS 15.0.1

**Toolchain Version:** Xcode 13.2.1

**SDK Version:** 15.2