### PR TITLE
Make CydiaSubstrate.tbd compatible with Zig's linker.

### DIFF
--- a/iphone/rootless/CydiaSubstrate.framework/CydiaSubstrate.tbd
+++ b/iphone/rootless/CydiaSubstrate.framework/CydiaSubstrate.tbd
@@ -1,11 +1,11 @@
----
-archs:           [ armv7, armv7s, arm64, arm64e ]
-platform:        ios
+--- !tapi-tbd
+tbd-version:    4
+targets:        [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
 install-name:    '@rpath/CydiaSubstrate.framework/CydiaSubstrate'
 current-version: 0.0.0
 compatibility-version: 0.0.0
 exports:
-  - archs:            [ armv7, armv7s, arm64, arm64e ]
+  - targets:          [armv7-ios, armv7s-ios, arm64-ios, arm64e-ios]
     symbols:          [ _MSCloseImage, _MSDebug, _MSFindAddress, _MSFindSymbol,
                         _MSGetImageByName, _MSHookClassPair, _MSHookFunction,
                         _MSHookMemory, _MSHookMessageEx, _MSImageAddress,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
This changes the format of rootless CydiaSubstrate.tbd to be compatible with more linkers, like zig's.
Ideally, this should be applied to all tbd files.

Does this close any currently open issues?
Nope.


Any relevant logs, error output, etc?
-------------------------------------
<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
Nope.
Any other comments?
Nope.

Where has this been tested?
---------------------------
**Operating System:** macOS Sonoma.

**Platform:** Intel.

**Target Platform:** aarch64-ios

**Toolchain Version:** N/A

**SDK Version:** N/A
