### PR TITLE
[CydiaSubstrate] Adjust imports to be compliant with module rules

### DIFF
--- a/CydiaSubstrate.framework/Headers/CydiaSubstrate.h
+++ b/CydiaSubstrate.framework/Headers/CydiaSubstrate.h
@@ -39,13 +39,7 @@
 #define SUBSTRATE_H_
 
 #ifdef __APPLE__
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <mach-o/nlist.h>
-#ifdef __cplusplus
-}
-#endif
 
 #include <objc/runtime.h>
 #include <objc/message.h>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

See linked issue and relevant logs below.

To resolve the error, this PR removes the `extern "C"` annotations around a system header.

Does this close any currently open issues?
------------------------------------------
Yes: https://github.com/theos/theos/issues/791

Any relevant logs, error output, etc?
-------------------------------------

When importing `CydiaSubstrate.h` into a C++ file and using an iOS SDK version 17 or later, you may encounter the error:

```
lib/CydiaSubstrate.framework/Headers/CydiaSubstrate.h:45:1: error: import of C++ module 'MachO.nlist' appears within extern "C" language linkage specification [-Wmodule-import-in-extern-c]
#include <mach-o/nlist.h>
^
lib/CydiaSubstrate.framework/Headers/CydiaSubstrate.h:43:1: note: extern "C" language linkage specification begins here
extern "C" {
^
```

Any other comments?
-------------------

Checked the iOS 5 SDK (thanks to this repo: <https://github.com/growtopiajaw/iPhoneOS-SDK>) that `mach-o/nlist.h` already wraps it's declarations with `extern "C"` as needed.

Where has this been tested?
---------------------------
**Operating System:** macOS

**Platform:** Darwin

**Target Platform:** iOS

**Toolchain Version:** `Apple clang version 15.0.0 (clang-1500.3.9.4)`

**SDK Version:** 17.4
